### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ In homebridge's config.json you need to specify homebridge-yeelighter as a platf
 ```
 "platforms": [
   {
-    "platform": "yeelighter"
+    "platform": "Yeelighter",
     "name": "Yeelighter"
   }
 ]
@@ -59,8 +59,8 @@ You can use the override array to override the automatic configuration of the li
 ```
 "platforms": [
   {
-    "platform": "yeelighter"
-    "name": "Yeelighter"
+    "platform": "Yeelighter",
+    "name": "Yeelighter",
     "override": [
       {
         "id": "0x00000000deadbeef",


### PR DESCRIPTION
1. Fix syntax error in example config. (adding "," at the end of the line)
2. Fix "platform" (platform name) to "Yeelighter" with capital Y. Using yeelighter in "platform" field seems will break HB with error "Platform yeelighter is not registered to any plugin."