### PR TITLE
Disable color temperature for background light

### DIFF
--- a/src/backgroundlightservice.ts
+++ b/src/backgroundlightservice.ts
@@ -43,26 +43,6 @@ export class BackgroundLightService extends LightService implements ConcreteLigh
       }
     );
 
-    const characteristic = await this.handleCharacteristic(
-      this.homebridge.hap.Characteristic.ColorTemperature,
-      async () => {
-        return convertColorTemperature((await this.attributes()).bg_ct);
-      },
-      value => {
-        this.ensurePowerMode(POWERMODE_CT, "bg_");
-        this.sendSuddenCommand("bg_set_ct_abx", convertColorTemperature(value));
-        if (this.light.detailedLogging) {
-          this.log(`setCT: ${convertColorTemperature(value)}`);
-        }
-        this.updateColorFromCT(value);
-        this.saveDefaultIfNeeded();
-      }
-    );
-    characteristic.setProps({
-      ...characteristic.props,
-      maxValue: convertColorTemperature(this.specs.colorTemperature.min),
-      minValue: convertColorTemperature(this.specs.colorTemperature.max)
-    });
     this.handleCharacteristic(
       this.homebridge.hap.Characteristic.Hue,
       async () => (await this.attributes()).bg_hue,
@@ -91,9 +71,5 @@ export class BackgroundLightService extends LightService implements ConcreteLigh
     this.updateCharacteristic(this.homebridge.hap.Characteristic.Hue, newAttributes.bg_hue);
     this.updateCharacteristic(this.homebridge.hap.Characteristic.On, newAttributes.bg_power);
     this.updateCharacteristic(this.homebridge.hap.Characteristic.Brightness, newAttributes.bg_bright);
-    this.updateCharacteristic(
-      this.homebridge.hap.Characteristic.ColorTemperature,
-      convertColorTemperature(newAttributes.bg_ct)
-    );
   };
 }

--- a/src/lightservice.ts
+++ b/src/lightservice.ts
@@ -3,7 +3,7 @@
 
 import { Light } from "./light";
 import { convertHomeKitColorTemperatureToHomeKitColor } from "./colortools";
-import { Specs } from "./Specs";
+import { Specs } from "./specs";
 
 // HACK: since importing these types will somehow create a dependency to hap-nodejs
 export type Accessory = any;


### PR DESCRIPTION
The HomeKit Accessory Protocol Specification states that color temperature cannot be used along with hue and saturation (chapter 8.107).

Fixes #10 