### PR TITLE
Turn the lamp on/off without changing the color mode.

### DIFF
--- a/src/colorlightservice.ts
+++ b/src/colorlightservice.ts
@@ -28,7 +28,7 @@ export class ColorLightService extends LightService implements ConcreteLightServ
     this.handleCharacteristic(
       this.homebridge.hap.Characteristic.On,
       async () => (await this.attributes()).power,
-      value => this.sendCommand("set_power", [value ? "on" : "off", "smooth", 500, POWERMODE_HSV])
+      value => this.sendCommand("set_power", [value ? "on" : "off", "smooth", 500, 0])
     );
     this.handleCharacteristic(
       this.homebridge.hap.Characteristic.Brightness,


### PR DESCRIPTION
I own a Yeelight Bedside Lamp 2. Whenever I turned it on via HomeKit, it changed to HSV mode, even if I set it to CT mode before. This pull request fixes this by bug by passing 0 (normal turn on operation) as "mode" parameter.