### PR TITLE
fix: improve socket reconnection reliability

### DIFF
--- a/src/colorlightservice.ts
+++ b/src/colorlightservice.ts
@@ -1,3 +1,4 @@
+import { AdaptiveLightingController, AdaptiveLightingControllerMode } from "homebridge";
 import {
   LightService,
   LightServiceParameters as LightServiceParameters,
@@ -10,10 +11,18 @@ import {
 } from "./lightservice";
 
 export class ColorLightService extends LightService implements ConcreteLightService {
+  private adaptiveLightingController?: AdaptiveLightingController;
+
   constructor(parameters: LightServiceParameters) {
     super(parameters);
     this.service.displayName = "Color Light";
     this.installHandlers();
+    if (this.platform.config.ctforcolor) {
+      this.adaptiveLightingController = new this.platform.AdaptiveLightingController(this.service, {
+        controllerMode: AdaptiveLightingControllerMode.AUTOMATIC
+      });
+      this.accessory.configureController(this.adaptiveLightingController);
+    }
   }
 
   private async installHandlers() {

--- a/src/specs.ts
+++ b/src/specs.ts
@@ -249,5 +249,12 @@ export const MODEL_SPECS: { [index: string]: Specs } = {
     backgroundLight: true,
     name: "Monitor Hanging Light",
     color: false
+  },
+  plate2: {
+    colorTemperature: { min: 1700, max: 6500 },
+    nightLight: false,
+    backgroundLight: false,
+    name: "Smart Light Panels",
+    color: true
   }
 };

--- a/src/specs.ts
+++ b/src/specs.ts
@@ -256,5 +256,26 @@ export const MODEL_SPECS: { [index: string]: Specs } = {
     backgroundLight: false,
     name: "Smart Light Panels",
     color: true
+  },
+  color8: {
+    colorTemperature: { min: 1700, max: 6500 },
+    nightLight: false,
+    backgroundLight: false,
+    name: "W3 Color Lightbulb",
+    color: true
+  },
+  colora: {
+    colorTemperature: { min: 1700, max: 6500 },
+    nightLight: false,
+    backgroundLight: false,
+    name: "W3 Color Lightbulb",
+    color: true
+  },
+  bslamp3: {
+    colorTemperature: { min: 1700, max: 6500 },
+    nightLight: false,
+    backgroundLight: false,
+    name: "Bedside Lamp D2",
+    color: true
   }
 };

--- a/src/yeeaccessory.ts
+++ b/src/yeeaccessory.ts
@@ -366,6 +366,10 @@ export class YeeAccessory {
       this.error("Failed to retrieve attributes", error);
     }
 
+    if (this.interval) {
+      clearInterval(this.interval);
+      delete this.interval;
+    }
     if (this.platform.config.interval !== 0) {
       this.interval = setInterval(this.onInterval, this.platform.config.interval || 60_000);
     }
@@ -385,6 +389,10 @@ export class YeeAccessory {
     if (this.interval) {
       clearInterval(this.interval);
       delete this.interval;
+    }
+    for (const [key, item] of this.transactions.entries()) {
+      item.reject(new Error("disconnected"));
+      this.transactions.delete(key);
     }
   };
 
@@ -488,7 +496,7 @@ export class YeeAccessory {
   private clearOldTransactions() {
     for (const [key, item] of this.transactions.entries()) {
       // clear transactions older than 60s
-      if (item.timestamp > Date.now() + 60_000) {
+      if (Date.now() - item.timestamp > 60_000) {
         this.log(`error: timeout for request ${key}`);
         item.reject(new Error("timeout"));
         this.transactions.delete(key);
@@ -499,7 +507,7 @@ export class YeeAccessory {
   private onInterval = () => {
     if (this.connected) {
       // if flooded wait for 5 minutes
-      if (this.floodAlarm && Date.now() - this.floodAlarm > 180_000_000) {
+      if (this.floodAlarm && Date.now() - this.floodAlarm > 300_000) {
         this.log(`flooded. waiting ${(Date.now() - this.floodAlarm) / 60_000}s`);
       } else {
         // seconds since last update

--- a/src/yeedevice.ts
+++ b/src/yeedevice.ts
@@ -93,6 +93,11 @@ export class Device extends EventEmitter {
   connect() {
     try {
       this.forceDisconnect = false;
+      if (this.socket) {
+        this.socket.removeAllListeners();
+        this.socket.destroy();
+        this.socket = undefined;
+      }
       this.socket = new net.Socket({ allowHalfOpen: false });
       this.bindSocket();
       this.socket.connect({ host: this.info.host, port: this.info.port }, () => {
@@ -138,20 +143,27 @@ export class Device extends EventEmitter {
     }
 
     if (error) {
-      if (error.message.includes("EHOSTUNREACH")) {
+      const msg = error.message ?? "";
+      if (msg.includes("EHOSTUNREACH")) {
         // unreachable, no need to retry
         this.disconnect(true);
       } else {
-        console.log(`Socket Closed with error "${error.name}, retrying to connect in 5s"`, error.message);
+        console.log(`Socket Closed with error "${error.name}, retrying to connect in 5s"`, msg);
         this.disconnect(false);
         if (this.retryTimer) {
           clearTimeout(this.retryTimer);
           delete this.retryTimer;
         }
-        this.retryTimer = setTimeout(this.connect.bind(this), 5000);
+        this.retryTimer = setTimeout(this.reconnect.bind(this), 5000);
       }
     } else {
+      // graceful close (e.g. device rebooted) — schedule reconnect
       this.disconnect(false);
+      if (this.retryTimer) {
+        clearTimeout(this.retryTimer);
+        delete this.retryTimer;
+      }
+      this.retryTimer = setTimeout(this.reconnect.bind(this), 5000);
     }
   }
 


### PR DESCRIPTION
 I kept running into an issue where my bulbs would go permanently offline and the only fix was restarting the plugin. The logs
  would fill up with:

  Socket Closed with error "Error, retrying to connect in 5s" connect ETIMEDOUT 169.254.118.86:55443

  After digging into the socket code I found a few issues causing this:

  The main one: when a bulb is power cycled it sends a graceful TCP FIN, which fires the end event rather than error. The
  socketClosed handler only scheduled a reconnect when called with an error — a graceful close just disconnected and never tried
   again, leaving the device permanently offline.

  Other issues I fixed while I was in there:

  - The retry path was calling connect() instead of reconnect(), which could spawn a new socket while a previous one was still
  connecting
  - Old sockets weren't being destroyed before creating new ones, leading to duplicate event handlers
  - setInterval in onDeviceConnected had no clearInterval guard, leaking timers on rapid reconnects
  - clearOldTransactions had an inverted condition (item.timestamp > Date.now() + 60_000) that meant stale transactions were
  never cleaned up
  - The floodAlarm threshold was 180_000_000ms (~50 hours) instead of the intended 5 minutes
  - error.message access could crash if the error had no message property

  After this change bulbs reconnect automatically after a power cycle with no plugin restart needed.
  
  Closes #69 (repeated socket errors flooding logs — fixed by proper reconnect on graceful close and orphaned socket cleanup)   
  Closes #116 (UnhandledPromiseRejection — fixed by rejecting pending transactions on disconnect)                               
  Closes #157 (Smart Light Panels colour not working — added plate2 spec)
  May fix #86 (CT slider no effect — stale transactions were silently dropping CT commands)
  May fix #112, #144 (Adaptive Lighting — stale transactions and 50hr floodAlarm suspension)
  May fix #154, #155, #156 (post-update regressions — floodAlarm and stale transaction fixes)